### PR TITLE
Refine GitHub Enterprise Server support and add `--verbose` option to all commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A [GitHub CLI](https://cli.github.com/) [extension](https://cli.github.com/manua
 
 You can use this tool to identify data that will be lost, or which you'll need to migrate manually, when migrating:
 
-* from GitHub Enterprise Server (GHES) to GitHub Enterprise Cloud (GHEC)
+* from GitHub Enterprise Server (GHES) v3.6 onwards to GitHub Enterprise Cloud (GHEC)
 * from GitHub Enterprise Cloud (GHEC) to GitHub Enterprise Server (GHES)
 * between tenants on GitHub.com (e.g. from a normal GitHub.com account to an [Enterprise Managed Users](https://docs.github.com/en/enterprise-cloud@latest/admin/identity-and-access-management/using-enterprise-managed-users-for-iam/about-enterprise-managed-users) organization)
 
@@ -51,9 +51,11 @@ gh migration-audit audit-repo \
     # OPTIONAL: The path to write the audit result CSV to. Defaults to the specified owner and repo, followed by the current date and time, e.g. `monalisa_octocat_1698925405325.csv
     --output-path octocat.csv \
     # OPTIONAL: The base URL of the GitHub API, if you're migrating from a migration source other than GitHub.com.
-    --base-url https://github.acme.inc/api/v3
+    --base-url https://github.acme.inc/api/v3 \
     # OPTIONAL: The URL of an HTTP(S) proxy to use for requests to the GitHub API (e.g. `http://localhost:3128`). This can also be set using the PROXY_URL environment variable.
-    --proxy-url https://10.0.0.1:3128
+    --proxy-url https://10.0.0.1:3128 \
+    # OPTIONAL: Whether to emit detailed, verbose logs
+    --verbose
 ```
 
 The tool will audit your repo, and then write a CSV file to the `--output-path` with the results.
@@ -75,9 +77,11 @@ gh migration-audit audit-all \
     # OPTIONAL: The path to write the audit result CSV to. Defaults to the specified owner followed by the current date and time, e.g. `monalisa_1698925405325.csv`.
     --output-path octocat.csv \
     # OPTIONAL: The base URL of the GitHub API, if you're migrating from a migration source other than GitHub.com.
-    --base-url https://github.acme.inc/api/v3
+    --base-url https://github.acme.inc/api/v3 \
     # OPTIONAL: The URL of an HTTP(S) proxy to use for requests to the GitHub API (e.g. `http://localhost:3128`). This can also be set using the PROXY_URL environment variable.
-    --proxy-url https://10.0.0.1:3128
+    --proxy-url https://10.0.0.1:3128 \
+    # OPTIONAL: Whether to emit detailed, verbose logs
+    --verbose
 ```
 
 The tool will audit all of the repos, and then write a CSV file to the `--output-path` with the results.
@@ -105,9 +109,11 @@ gh migration-audit audit-repos \
     # OPTIONAL: The path to write the audit result CSV to. Defaults to the "repos" followed by the current date and time, e.g. `repos_1698925405325.csv`.
     --output-path octocat.csv \
     # OPTIONAL: The base URL of the GitHub API, if you're migrating from a migration source other than GitHub.com.
-    --base-url https://github.acme.inc/api/v3
+    --base-url https://github.acme.inc/api/v3 \
     # OPTIONAL: The URL of an HTTP(S) proxy to use for requests to the GitHub API (e.g. `http://localhost:3128`). This can also be set using the PROXY_URL environment variable.
-    --proxy-url https://10.0.0.1:3128
+    --proxy-url https://10.0.0.1:3128 \
+    # OPTIONAL: Whether to emit detailed, verbose logs
+    --verbose
 ```
 
 The tool will audit all of the repos, and then write a CSV file to the `--output-path` with the results.

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ gh migration-audit audit-repos \
     --access-token GITHUB_TOKEN \
     # The path to a input CSV file with a list of repos to audit. The file should have a header row with the columns `owner` and `name`, followed by a series of rows.
     --input-path input.csv \
-    # OPTIONAL: The path to write the audit result CSV to. Defaults to the specified owner followed by the current date and time, e.g. `monalisa_1698925405325.csv`.
+    # OPTIONAL: The path to write the audit result CSV to. Defaults to the "repos" followed by the current date and time, e.g. `repos_1698925405325.csv`.
     --output-path octocat.csv \
     # OPTIONAL: The base URL of the GitHub API, if you're migrating from a migration source other than GitHub.com.
     --base-url https://github.acme.inc/api/v3

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "commander": "^11.1.0",
         "csv-stringify": "^6.4.4",
         "octokit": "^3.1.1",
+        "semver": "^7.5.4",
         "undici": "^5.27.0",
         "winston": "^3.11.0"
       },

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "commander": "^11.1.0",
     "csv-stringify": "^6.4.4",
     "octokit": "^3.1.1",
+    "semver": "^7.5.4",
     "undici": "^5.27.0",
     "winston": "^3.11.0"
   },

--- a/src/auditors/repository-actions-secrets.ts
+++ b/src/auditors/repository-actions-secrets.ts
@@ -1,6 +1,4 @@
-import type { Octokit } from 'octokit';
-
-import { AuditorWarning } from '../types';
+import { AuditorFunctionArgs, AuditorWarning } from '../types';
 import { pluralize } from '../utils';
 
 export const TYPE = 'repository-actions-secrets';
@@ -9,16 +7,30 @@ export const auditor = async ({
   octokit,
   owner,
   repo,
-}: {
-  octokit: Octokit;
-  owner: string;
-  repo: string;
-}): Promise<AuditorWarning[]> => {
-  const { data } = await octokit.rest.actions.listRepoSecrets({
-    owner,
-    repo,
-    per_page: 1,
-  });
+  logger,
+}: AuditorFunctionArgs): Promise<AuditorWarning[]> => {
+  let data;
+
+  try {
+    const response = await octokit.rest.actions.listRepoSecrets({
+      owner,
+      repo,
+      per_page: 1,
+    });
+
+    data = response.data;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } catch (error: any) {
+    if (error.status && error.status == 500) {
+      logger.warn(
+        'Unable to check for Actions secrets because the REST API returned `500 Internal Server Error`. This usually means that Actions is turned off.',
+        { owner, repo },
+      );
+      return [];
+    } else {
+      throw error;
+    }
+  }
 
   if (data.total_count > 0) {
     return [

--- a/src/auditors/repository-actions-variables.ts
+++ b/src/auditors/repository-actions-variables.ts
@@ -1,19 +1,23 @@
-import type { Octokit } from 'octokit';
+import semver from 'semver';
 
-import { AuditorWarning } from '../types';
+import { AuditorFunction, AuditorWarning } from '../types';
 import { pluralize } from '../utils';
 
 export const TYPE = 'repository-actions-variables';
 
-export const auditor = async ({
+export const auditor: AuditorFunction = async ({
+  gitHubEnterpriseServerVersion,
   octokit,
   owner,
   repo,
-}: {
-  octokit: Octokit;
-  owner: string;
-  repo: string;
 }): Promise<AuditorWarning[]> => {
+  if (
+    typeof gitHubEnterpriseServerVersion !== 'undefined' &&
+    semver.lt(gitHubEnterpriseServerVersion, '3.8.0')
+  ) {
+    return [];
+  }
+
   const { data } = await octokit.rest.actions.listRepoVariables({
     owner,
     repo,

--- a/src/auditors/repository-codespaces-secrets.ts
+++ b/src/auditors/repository-codespaces-secrets.ts
@@ -1,19 +1,18 @@
-import type { Octokit } from 'octokit';
-
-import { AuditorWarning } from '../types';
+import { AuditorFunction, AuditorWarning } from '../types';
 import { pluralize } from '../utils';
 
 export const TYPE = 'repository-codespaces-secrets';
 
-export const auditor = async ({
+export const auditor: AuditorFunction = async ({
+  gitHubEnterpriseServerVersion,
   octokit,
   owner,
   repo,
-}: {
-  octokit: Octokit;
-  owner: string;
-  repo: string;
 }): Promise<AuditorWarning[]> => {
+  if (typeof gitHubEnterpriseServerVersion !== 'undefined') {
+    return [];
+  }
+
   const { data } = await octokit.rest.codespaces.listRepoSecrets({
     owner,
     repo,

--- a/src/github-products.ts
+++ b/src/github-products.ts
@@ -1,0 +1,60 @@
+import type { Octokit } from 'octokit';
+import { Endpoints } from '@octokit/types';
+import semver from 'semver';
+
+type DotcomMetaResponse = Endpoints['GET /meta']['response'];
+
+// Octokit's default types target GitHub.com where there is no `installed_version` returned
+// from this API. We construct our own type which includes this.
+type GhesMetaResponse = DotcomMetaResponse & {
+  data: {
+    installed_version: string;
+  };
+};
+
+export const MINIMUM_SUPPORTED_GITHUB_ENTERPRISE_SERVER_VERSION = '3.6.0';
+
+export const isSupportedGitHubEnterpriseServerVersion = (version: string) =>
+  semver.gte(version, MINIMUM_SUPPORTED_GITHUB_ENTERPRISE_SERVER_VERSION);
+
+export const getGitHubProductInformation = async (
+  octokit: Octokit,
+): Promise<
+  | {
+      isGitHubEnterpriseServer: true;
+      gitHubEnterpriseServerVersion: string;
+    }
+  | {
+      isGitHubEnterpriseServer: false;
+      gitHubEnterpriseServerVersion: undefined;
+    }
+> => {
+  const isGitHubEnterpriseServer = isGitHubEnterpriseServerBaseUrl(
+    octokit.request.endpoint.DEFAULTS.baseUrl,
+  );
+
+  if (isGitHubEnterpriseServer) {
+    const gitHubEnterpriseServerVersion = await getGitHubEnterpriseServerVersion(octokit);
+
+    return {
+      isGitHubEnterpriseServer,
+      gitHubEnterpriseServerVersion,
+    };
+  } else {
+    return {
+      isGitHubEnterpriseServer,
+      gitHubEnterpriseServerVersion: undefined,
+    };
+  }
+};
+
+const isGitHubEnterpriseServerBaseUrl = (baseUrl: string): boolean =>
+  baseUrl !== 'https://api.github.com';
+
+const getGitHubEnterpriseServerVersion = async (octokit: Octokit): Promise<string> => {
+  const {
+    data: { installed_version },
+  } = (await octokit.rest.meta.get()) as GhesMetaResponse;
+
+  return installed_version;
+};

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -3,9 +3,13 @@ const { combine, timestamp, printf, colorize } = winston.format;
 
 // TODO: Figure out how to make ESLint happy with this
 // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-const format = printf(({ level, message, timestamp }): string => {
+const format = printf(({ level, message, timestamp, owner, repo }): string => {
   // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-  return `${timestamp} ${level}: ${message}`;
+  if (owner && repo) {
+    return `${timestamp} ${level} [${owner}/${repo}]: ${message}`;
+  } else {
+    return `${timestamp} ${level}: ${message}`;
+  }
 });
 
 const generateLoggerOptions = (verbose: boolean): winston.LoggerOptions => {

--- a/src/octokit.ts
+++ b/src/octokit.ts
@@ -38,6 +38,9 @@ export const createOctokit = (
     auth: token,
     baseUrl,
     request: { fetch: fetch || customFetch },
+    retry: {
+      enabled: false,
+    },
     throttle: {
       onRateLimit: (retryAfter, options) => {
         const { method, url } = options as OnRateLimitOptions;

--- a/src/repositories.ts
+++ b/src/repositories.ts
@@ -21,9 +21,6 @@ export const getRepositoryWithGraphql = async ({
         discussions(first: 1) {
           totalCount
         }
-        rulesets(first: 1) {
-          totalCount
-        }
       }
     }`,
     {

--- a/src/repository-auditor.ts
+++ b/src/repository-auditor.ts
@@ -35,11 +35,13 @@ export const auditRepositories = async ({
   nameWithOwners,
   logger,
   auditors = DEFAULT_AUDITORS,
+  gitHubEnterpriseServerVersion,
 }: {
   octokit: Octokit;
   nameWithOwners: NameWithOwner[];
   logger: winston.Logger;
   auditors?: Auditor[];
+  gitHubEnterpriseServerVersion: string | undefined;
 }): Promise<AuditWarning[]> => {
   const warnings: AuditWarning[] = [];
 
@@ -50,6 +52,7 @@ export const auditRepositories = async ({
       repo: name,
       logger,
       auditors,
+      gitHubEnterpriseServerVersion,
     });
 
     warnings.push(
@@ -66,12 +69,14 @@ export const auditRepository = async ({
   repo,
   logger,
   auditors = DEFAULT_AUDITORS,
+  gitHubEnterpriseServerVersion,
 }: {
   octokit: Octokit;
   owner: string;
   repo: string;
   logger: winston.Logger;
   auditors?: Auditor[];
+  gitHubEnterpriseServerVersion: string | undefined;
 }): Promise<RepositoryAuditWarning[]> => {
   const graphqlRepository = await getRepositoryWithGraphql({
     owner,
@@ -89,6 +94,7 @@ export const auditRepository = async ({
       repo,
       graphqlRepository,
       logger,
+      gitHubEnterpriseServerVersion,
     );
     warnings.push(...auditWarnings);
   }
@@ -103,12 +109,27 @@ const runAuditor = async (
   repo: string,
   graphqlRepository: GraphqlRepository,
   logger: winston.Logger,
+  gitHubEnterpriseServerVersion: string | undefined,
 ): Promise<RepositoryAuditWarning[]> => {
+  logger.debug(`Running auditor ${auditor.TYPE}`, { owner, repo });
+
   try {
-    const warnings = await auditor.auditor({ graphqlRepository, octokit, owner, repo });
+    const warnings = await auditor.auditor({
+      graphqlRepository,
+      octokit,
+      owner,
+      repo,
+      gitHubEnterpriseServerVersion,
+      logger,
+    });
     return warnings.map((auditorWarning) => ({ ...auditorWarning, type: auditor.TYPE }));
   } catch (e) {
-    logger.error(`Auditor \`${auditor.TYPE}\` failed with error: ${presentError(e)}`);
+    logger.error(
+      `Auditor \`${auditor.TYPE}\` failed for ${owner}/${repo} with error: ${presentError(
+        e,
+      )}`,
+      { owner, repo },
+    );
     return [];
   }
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,10 +1,8 @@
 import type { Octokit } from 'octokit';
+import winston from 'winston';
 
 export interface GraphqlRepository {
   id: string;
-  rulesets: {
-    totalCount: number;
-  };
   discussions: {
     totalCount: number;
   };
@@ -31,17 +29,23 @@ export interface NameWithOwner {
   name: string;
 }
 
+export type AuditorFunctionArgs = {
+  graphqlRepository: GraphqlRepository;
+  octokit: Octokit;
+  owner: string;
+  repo: string;
+  gitHubEnterpriseServerVersion: string | undefined;
+  logger: winston.Logger;
+};
+
 export type AuditorFunction = ({
   graphqlRepository,
   octokit,
   owner,
   repo,
-}: {
-  graphqlRepository: GraphqlRepository;
-  octokit: Octokit;
-  owner: string;
-  repo: string;
-}) => Promise<AuditorWarning[]>;
+  gitHubEnterpriseServerVersion,
+  logger,
+}: AuditorFunctionArgs) => Promise<AuditorWarning[]>;
 
 export interface Auditor {
   TYPE: string;

--- a/test/auditors/repository-actions-secrets.test.ts
+++ b/test/auditors/repository-actions-secrets.test.ts
@@ -42,4 +42,15 @@ describe('repositoryActionSecrets', () => {
 
     expect(warnings).toEqual([]);
   });
+
+  it('returns no warnings if the API returns a 500', async () => {
+    const fetch = fetchMock
+      .sandbox()
+      .getOnce('https://api.github.com/repos/test/test/actions/secrets?per_page=1', 500);
+
+    const auditorArguments = buildAuditorArguments({ fetchMock: fetch });
+    const warnings = await auditor(auditorArguments);
+
+    expect(warnings).toEqual([]);
+  });
 });

--- a/test/auditors/repository-actions-variables.test.ts
+++ b/test/auditors/repository-actions-variables.test.ts
@@ -43,4 +43,30 @@ describe('repositoryActionVariables', () => {
 
     expect(warnings).toEqual([]);
   });
+
+  it('no-ops if running against GitHub Enterprise Server <3.8', async () => {
+    const auditorArguments = buildAuditorArguments({
+      gitHubEnterpriseServerVersion: '3.7.3',
+    });
+    const warnings = await auditor(auditorArguments);
+
+    expect(warnings.length).toEqual(0);
+  });
+
+  it('runs if running against GitHub Enterprise Server >=3.8', async () => {
+    const fetch = fetchMock
+      .sandbox()
+      .getOnce('https://api.github.com/repos/test/test/actions/variables?per_page=1', {
+        total_count: 0,
+        variables: [],
+      });
+
+    const auditorArguments = buildAuditorArguments({
+      fetchMock: fetch,
+      gitHubEnterpriseServerVersion: '3.8.0',
+    });
+    const warnings = await auditor(auditorArguments);
+
+    expect(warnings.length).toEqual(0);
+  });
 });

--- a/test/auditors/repository-codespaces-secrets.test.ts
+++ b/test/auditors/repository-codespaces-secrets.test.ts
@@ -42,4 +42,13 @@ describe('repositoryCodespacesSecrets', () => {
 
     expect(warnings).toEqual([]);
   });
+
+  it('no-ops if running against GitHub Enterprise Server', async () => {
+    const auditorArguments = buildAuditorArguments({
+      gitHubEnterpriseServerVersion: '3.10.0',
+    });
+    const warnings = await auditor(auditorArguments);
+
+    expect(warnings.length).toEqual(0);
+  });
 });

--- a/test/auditors/repository-dependabot-secrets.test.ts
+++ b/test/auditors/repository-dependabot-secrets.test.ts
@@ -41,4 +41,18 @@ describe('repositoryDependabotSecrets', () => {
 
     expect(warnings).toEqual([]);
   });
+
+  it('returns no warnings if the API returns a 500', async () => {
+    const fetch = fetchMock
+      .sandbox()
+      .getOnce(
+        'https://api.github.com/repos/test/test/dependabot/secrets?per_page=1',
+        500,
+      );
+
+    const auditorArguments = buildAuditorArguments({ fetchMock: fetch });
+    const warnings = await auditor(auditorArguments);
+
+    expect(warnings).toEqual([]);
+  });
 });

--- a/test/auditors/repository-rulesets.test.ts
+++ b/test/auditors/repository-rulesets.test.ts
@@ -1,21 +1,52 @@
-import { buildRepository } from '../helpers/repositories';
+import fetchMock from 'fetch-mock';
 import { auditor } from '../../src/auditors/repository-rulesets';
+import { buildAuditorArguments } from '../helpers/auditors';
 
 describe('repository-rulesets', () => {
   it('returns a warning if there are rulesets', async () => {
-    const graphqlRepository = buildRepository({ rulesets: { totalCount: 1 } });
-    const warnings = await auditor({ graphqlRepository });
+    const fetch = fetchMock
+      .sandbox()
+      .getOnce(
+        'https://api.github.com/repos/test/test/rulesets?per_page=1&includes_parents=true',
+        [1, 2],
+      );
+
+    const auditorArguments = buildAuditorArguments({
+      fetchMock: fetch,
+    });
+
+    const warnings = await auditor(auditorArguments);
 
     expect(warnings).toEqual([
       {
-        message: '1 ruleset applies to this repository, which will not be migrated',
+        message:
+          'One or more repository or organization rulesets apply to this repository, which will not be migrated',
       },
     ]);
   });
 
   it('returns no warnings if there are no rulesets', async () => {
-    const graphqlRepository = buildRepository({ discussions: { totalCount: 0 } });
-    const warnings = await auditor({ graphqlRepository });
+    const fetch = fetchMock
+      .sandbox()
+      .getOnce(
+        'https://api.github.com/repos/test/test/rulesets?per_page=1&includes_parents=true',
+        [],
+      );
+
+    const auditorArguments = buildAuditorArguments({
+      fetchMock: fetch,
+    });
+
+    const warnings = await auditor(auditorArguments);
+
+    expect(warnings.length).toEqual(0);
+  });
+
+  it('no-ops if running against GitHub Enterprise Server', async () => {
+    const auditorArguments = buildAuditorArguments({
+      gitHubEnterpriseServerVersion: '3.10.0',
+    });
+    const warnings = await auditor(auditorArguments);
 
     expect(warnings.length).toEqual(0);
   });

--- a/test/helpers/auditors.ts
+++ b/test/helpers/auditors.ts
@@ -1,4 +1,4 @@
-import { GraphqlRepository } from '../../src/types.js';
+import { AuditorFunctionArgs, GraphqlRepository } from '../../src/types.js';
 import { createOctokit } from '../../src/octokit';
 import { createLogger } from 'winston';
 import { buildRepository } from './repositories';
@@ -7,10 +7,12 @@ import { FetchMockSandbox } from 'fetch-mock';
 export const buildAuditorArguments = ({
   graphqlRepositoryOverrides,
   fetchMock,
+  gitHubEnterpriseServerVersion,
 }: {
   graphqlRepositoryOverrides?: Partial<GraphqlRepository>;
   fetchMock?: FetchMockSandbox;
-} = {}) => {
+  gitHubEnterpriseServerVersion?: string;
+}): AuditorFunctionArgs => {
   const graphqlRepository = buildRepository(graphqlRepositoryOverrides);
   const logger = createLogger();
 
@@ -25,6 +27,8 @@ export const buildAuditorArguments = ({
   return {
     graphqlRepository,
     octokit,
+    gitHubEnterpriseServerVersion,
+    logger,
     owner: 'test',
     repo: 'test',
   };

--- a/test/helpers/repositories.ts
+++ b/test/helpers/repositories.ts
@@ -5,9 +5,6 @@ export const buildRepository = (
 ): GraphqlRepository => {
   return {
     id: 'test',
-    rulesets: {
-      totalCount: 0,
-    },
     discussions: {
       totalCount: 0,
     },

--- a/test/repository-auditor.test.ts
+++ b/test/repository-auditor.test.ts
@@ -40,6 +40,7 @@ describe('auditRepository', () => {
       repo: 'repo',
       logger,
       auditors: AUDITORS,
+      gitHubEnterpriseServerVersion: undefined,
     });
 
     expect(warnings).toEqual([
@@ -83,6 +84,7 @@ describe('auditRepositories', () => {
       nameWithOwners,
       logger,
       auditors: AUDITORS,
+      gitHubEnterpriseServerVersion: undefined,
     });
 
     expect(warnings).toEqual([


### PR DESCRIPTION
This refines the tool's support for GitHub Enterprise Server, targeting (for now) support for GHES 3.6 onwards.

When starting, the CLI checks the version of the API target and errors if running an unsupported GHES version.

Auditors are passed `isGitHubEnterpriseServer` and `gitHubEnterpriseServerVersion` arguments, and can decide how to behave.

As part of this change, I have updated some existing auditors to deal with GitHub Enterprise Server - for example, rulesets are not available on GHES at all (and therefore the audit should no-op), Actions variables are only available on GHES 3.8+ (and therefore the audit should no-op on earlier versions) and some APIs exhibit odd behaviour in GHES when Actions is disabled which must be handled.