### PR TITLE
Refactor Workflows. Package and Release are now part of CI WF

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       # Upload are done in two different steps otherwise they will share the common base path
       # and the artifacts structure will be odd. Since on the first step we uploads just a file
       # it will be kept in the _root_ of the artifact, while the second step will upload directory structures
-      - name: Upload
+      - name: Upload Event
         if: always()
         uses: actions/upload-artifact@v3
         with:
@@ -40,7 +40,7 @@ jobs:
             retention-days: 1
             path: ${{ github.event_path }}
 
-      - name: Upload
+      - name: Upload Test Results and Coverage
         if: always()
         uses: actions/upload-artifact@v3
         with:
@@ -49,4 +49,76 @@ jobs:
             path: |
               test-results/**
               coverage/**
+
+  package:
+    name: Package binaries
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Setup Node.js
+        uses: actions/setup-node@v4.0.0
+        with:
+          node-version: 18.x
+      - name: Install dependencies
+        run: npm ci
+      - name: Generate binaries for macOS, Linux and Windows
+        run: npm run package
+      - name: Rename macOS binary to conform to GitHub CLI extension rules
+        run: mv bin/migration-audit-macos bin/gh-migration-audit-darwin-amd64
+      - name: Rename Windows binary to conform to GitHub CLI extension rules
+        run: mv bin/migration-audit-win.exe bin/gh-migration-audit-windows-amd64.exe
+      - name: Rename Linux binary to conform to GitHub CLI extension rules
+        run: mv bin/migration-audit-linux bin/gh-migration-audit-linux-amd64
+      - name: Upload macOS binary as artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: package-macos
+          path: bin/gh-migration-audit-darwin-amd64
+      - name: Upload Linux binary as artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: package-linux
+          path: bin/gh-migration-audit-linux-amd64
+      - name: Upload Windows binary as artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: package-windows
+          path: bin/gh-migration-audit-windows-amd64.exe
+  create_release:
+    name: Create release
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    needs: ['package','test_and_lint']
+
+    permissions:
+      contents: write
+
+    steps:
+      - name: Download Windows binary
+        uses: actions/download-artifact@v3
+        with:
+          name: package-windows
+          path: bin
+      - name: Download macOS binary
+        uses: actions/download-artifact@v3
+        with:
+          name: package-macos
+          path: bin
+      - name: Download Linux binary
+        uses: actions/download-artifact@v3
+        with:
+          name: package-linux
+          path: bin
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            bin/gh-migration-audit-darwin-amd64
+            bin/gh-migration-audit-linux-amd64
+            bin/gh-migration-audit-windows-amd64.exe
+          generate_release_notes: true
 

--- a/.github/workflows/end-2-end-tests-and-release.yml
+++ b/.github/workflows/end-2-end-tests-and-release.yml
@@ -8,57 +8,21 @@ on:
 
 permissions:
   contents: read
+  checks: write
 
 jobs:
-  package:
-    name: Package binaries
-    runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Setup Node.js
-        uses: actions/setup-node@v4.0.0
-        with:
-          node-version: 18.x
-      - name: Install dependencies
-        run: npm ci
-      - name: Generate binaries for macOS, Linux and Windows
-        run: npm run package
-      - name: Rename macOS binary to conform to GitHub CLI extension rules
-        run: mv bin/migration-audit-macos bin/gh-migration-audit-darwin-amd64
-      - name: Rename Windows binary to conform to GitHub CLI extension rules
-        run: mv bin/migration-audit-win.exe bin/gh-migration-audit-windows-amd64.exe
-      - name: Rename Linux binary to conform to GitHub CLI extension rules
-        run: mv bin/migration-audit-linux bin/gh-migration-audit-linux-amd64
-      - name: Upload macOS binary as artifact
-        uses: actions/upload-artifact@v3
-        with:
-          name: package-macos
-          path: bin/gh-migration-audit-darwin-amd64
-      - name: Upload Linux binary as artifact
-        uses: actions/upload-artifact@v3
-        with:
-          name: package-linux
-          path: bin/gh-migration-audit-linux-amd64
-      - name: Upload Windows binary as artifact
-        uses: actions/upload-artifact@v3
-        with:
-          name: package-windows
-          path: bin/gh-migration-audit-windows-amd64.exe
-
   end_to_end_tests_macos:
     name: Run end to end tests (macOS)
     runs-on: macos-latest
-    needs: package
+    env:
+      check_name: Integration Tests macOS
 
     steps:
+
       - name: Download macOS binary
-        uses: actions/download-artifact@v3
+        uses: dawidd6/action-download-artifact@268677152d06ba59fcec7a7f0b5d961b6ccd7e1e
         with:
+          run_id: ${{ github.event.workflow_run.id }}
           name: package-macos
           path: bin
       - name: Create `output` directory
@@ -88,17 +52,28 @@ jobs:
         with:
           name: macos-outputs
           path: output
+      - name: Set Status Check
+        uses: LouisBrunner/checks-action@c6dbaea4f9c79ccfe67c038acddaf713518b255d
+        if: always()
+        with:
+          sha: ${{ github.event.workflow_run.head_sha}}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          name: ${{ env.check_name }}
+          conclusion: ${{ job.status }}
+  
   end_to_end_tests_linux:
     name: Run end to end tests (Linux)
     runs-on: ubuntu-latest
-    needs: package
+    env:
+      check_name: Integration Tests Linux
 
     steps:
       - name: Download Linux binary
-        uses: actions/download-artifact@v3
+        uses: dawidd6/action-download-artifact@268677152d06ba59fcec7a7f0b5d961b6ccd7e1e
         with:
-          name: package-linux
-          path: bin
+           run_id: ${{ github.event.workflow_run.id }}
+           name: package-linux
+           path: bin
       - name: Create `output` directory
         run: mkdir output
       - name: Make Linux binary executable
@@ -126,16 +101,34 @@ jobs:
         with:
           name: linux-outputs
           path: output
+      - name: Upload
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+            name: dbg
+            retention-days: 1
+            path: ${{ github.event_path }}
+
+      - name: Set Status Check
+        uses: LouisBrunner/checks-action@c6dbaea4f9c79ccfe67c038acddaf713518b255d
+        if: always()
+        with:
+          sha: ${{ github.event.workflow_run.head_sha}}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          name: ${{ env.check_name }}
+          conclusion: ${{ job.status }}
 
   end_to_end_tests_windows:
     name: Run end to end tests (Windows)
     runs-on: windows-latest
-    needs: package
+    env:
+      check_name: Integration Tests Windows
 
     steps:
       - name: Download Windows binary
-        uses: actions/download-artifact@v3
+        uses: dawidd6/action-download-artifact@268677152d06ba59fcec7a7f0b5d961b6ccd7e1e
         with:
+          run_id: ${{ github.event.workflow_run.id }}
           name: package-windows
           path: bin
       - name: Create `output` directory
@@ -163,37 +156,11 @@ jobs:
         with:
           name: windows-outputs
           path: output
-
-  create_release:
-    name: Create release
-    if: startsWith(github.ref, 'refs/tags/')
-    runs-on: ubuntu-latest
-    needs: [end_to_end_tests_linux, end_to_end_tests_macos, end_to_end_tests_windows]
-
-    permissions:
-      contents: write
-
-    steps:
-      - name: Download Windows binary
-        uses: actions/download-artifact@v3
+      - name: Set Status Check
+        uses: LouisBrunner/checks-action@c6dbaea4f9c79ccfe67c038acddaf713518b255d
+        if: always()
         with:
-          name: package-windows
-          path: bin
-      - name: Download macOS binary
-        uses: actions/download-artifact@v3
-        with:
-          name: package-macos
-          path: bin
-      - name: Download Linux binary
-        uses: actions/download-artifact@v3
-        with:
-          name: package-linux
-          path: bin
-      - name: Create GitHub release
-        uses: softprops/action-gh-release@v1
-        with:
-          files: |
-            bin/gh-migration-audit-darwin-amd64
-            bin/gh-migration-audit-linux-amd64
-            bin/gh-migration-audit-windows-amd64.exe
-          generate_release_notes: true
+          sha: ${{ github.event.workflow_run.head_sha}}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          name: ${{ env.check_name }}
+          conclusion: ${{ job.status }}


### PR DESCRIPTION
The CI now packages the 3 binaries and uploads them to artifacts, it optionally creates a release when a tag is pushed.

The integration tests no longer build the binaries, it just uses the binaries packaged during CI.

Integration tests now publish a check status so commits and PR can have a view on integration tests results.