### PR TITLE
Add end-to-end test coverage for GitHub Enterprise Server 3.6

### DIFF
--- a/.github/workflows/end-to-end-tests.yml
+++ b/.github/workflows/end-to-end-tests.yml
@@ -1,4 +1,4 @@
-name: End to End tests and release
+name: End to end tests
 on:
   workflow_run:
     workflows:
@@ -7,18 +7,18 @@ on:
       - completed
 
 permissions:
+  actions: read
   contents: read
   checks: write
 
 jobs:
   end_to_end_tests_macos:
-    name: Run end to end tests (macOS)
+    name: Run end to end tests (macOS/GitHub.com)
     runs-on: macos-latest
     env:
-      check_name: Integration Tests macOS
+      check_name: End to end tests (macOS/GitHub.com)
 
     steps:
-
       - name: Download macOS binary
         uses: dawidd6/action-download-artifact@268677152d06ba59fcec7a7f0b5d961b6ccd7e1e
         with:
@@ -62,10 +62,10 @@ jobs:
           conclusion: ${{ job.status }}
   
   end_to_end_tests_linux:
-    name: Run end to end tests (Linux)
+    name: Run end to end tests (Linux/GitHub.com)
     runs-on: ubuntu-latest
     env:
-      check_name: Integration Tests Linux
+      check_name: End to end tests (Linux/GitHub.com)
 
     steps:
       - name: Download Linux binary
@@ -119,10 +119,10 @@ jobs:
           conclusion: ${{ job.status }}
 
   end_to_end_tests_windows:
-    name: Run end to end tests (Windows)
+    name: Run end to end tests (Windows/GitHub.com)
     runs-on: windows-latest
     env:
-      check_name: Integration Tests Windows
+      check_name: End to end tests (Windows/GitHub.com)
 
     steps:
       - name: Download Windows binary
@@ -156,6 +156,63 @@ jobs:
         with:
           name: windows-outputs
           path: output
+      - name: Set Status Check
+        uses: LouisBrunner/checks-action@c6dbaea4f9c79ccfe67c038acddaf713518b255d
+        if: always()
+        with:
+          sha: ${{ github.event.workflow_run.head_sha}}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          name: ${{ env.check_name }}
+          conclusion: ${{ job.status }}
+
+  end_to_end_tests_linux_ghes:
+    name: Run end to end tests (Linux/GitHub Enterprise Server)
+    runs-on: ubuntu-latest
+    env:
+      check_name: End to end tests (Linux/GitHub Enterprise Server)
+
+    steps:
+      - name: Download Linux binary
+        uses: dawidd6/action-download-artifact@268677152d06ba59fcec7a7f0b5d961b6ccd7e1e
+        with:
+           run_id: ${{ github.event.workflow_run.id }}
+           name: package-linux
+           path: bin
+      - name: Create `output` directory
+        run: mkdir output
+      - name: Make Linux binary executable
+        run: chmod +x bin/gh-migration-audit-linux-amd64
+      - name: Audit a single repo
+        run: ./bin/gh-migration-audit-linux-amd64 audit-repo --owner gh-migration-audit-sandbox --repo second-repo-with-actions-variables --output-path output/audit-repo.csv --base-url ${{ secrets.GHES_BASE_URL }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GHES_TOKEN }}
+      - name: Audit repos owned by an organization
+        run: ./bin/gh-migration-audit-linux-amd64 audit-all --owner gh-migration-audit-sandbox --output-path output/audit-all.csv --base-url ${{ secrets.GHES_BASE_URL }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GHES_TOKEN }}
+      - name: Create input CSV for audit-repos
+        run: |
+          echo "owner,name
+          gh-migration-audit-sandbox,second-repo-with-actions-variables" > input.csv
+      - name: Print input CSV
+        run: cat input.csv
+      - name: Audit specific repos from input CSV
+        run: ./bin/gh-migration-audit-linux-amd64 audit-repos --input-path input.csv --output-path output/audit-repos.csv --base-url ${{ secrets.GHES_BASE_URL }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GHES_TOKEN }}
+      - name: Upload outputs as artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: linux-github-enterprise-server-outputs
+          path: output
+      - name: Upload
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+            name: dbg
+            retention-days: 1
+            path: ${{ github.event_path }}
+
       - name: Set Status Check
         uses: LouisBrunner/checks-action@c6dbaea4f9c79ccfe67c038acddaf713518b255d
         if: always()


### PR DESCRIPTION
This adds end-to-end test coverage for GitHub Enterprise Server 3.6, providing that we can successfully run an audit against the earliest supported version of Enterprise Server without exploding, just as we do for GitHub.com.

As part of this change, I've also made some cosmetic naming tweaks.

In a follow up PR, we may want to additionally test migrations between GitHub.com and GHES, but this is a great start to build confidence.