### PR TITLE
Drop support for GitHub Enterprise Server 3.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A [GitHub CLI](https://cli.github.com/) [extension](https://cli.github.com/manua
 
 You can use this tool to identify data that will be lost, or which you'll need to migrate manually, when migrating:
 
-* from GitHub Enterprise Server (GHES) v3.6 onwards to GitHub Enterprise Cloud (GHEC)
+* from GitHub Enterprise Server (GHES) v3.7 onwards to GitHub Enterprise Cloud (GHEC)
 * from GitHub Enterprise Cloud (GHEC) to GitHub Enterprise Server (GHES)
 * between tenants on GitHub.com (e.g. from a normal GitHub.com account to an [Enterprise Managed Users](https://docs.github.com/en/enterprise-cloud@latest/admin/identity-and-access-management/using-enterprise-managed-users-for-iam/about-enterprise-managed-users) organization)
 
@@ -149,4 +149,4 @@ If you identify a piece of data that isn't automatically migrated which isn't de
 1. Update your new auditor to check for unmigratable data and return a warning if there is data which can't be migrated. You may be able to use GraphQL data from step 2, or you can make a fresh API request from your auditor using the `octokit`, `owner` and `repo` passed to the function. 
 1. Write a unit test for your auditor in `test/auditors`, using an existing one as a template.
 1. Update `DEFAULT_AUDITORS` in `src/repository-auditor.ts`, importing and adding the auditor you created
-1. Create a pull request with your changes, including evidence of your functional testing to make sure the auditor works on. If possible, please also test with the oldest supported GitHub Enterprise Server version (v3.6).
+1. Create a pull request with your changes, including evidence of your functional testing to make sure the auditor works on. If possible, please also test with the oldest supported GitHub Enterprise Server version (v3.7).

--- a/README.md
+++ b/README.md
@@ -137,6 +137,16 @@ gh migration-audit audit-repos \
 
 The tool will audit all of the repos, and then write a CSV file to the `--output-path` with the results.
 
+## GitHub Enterprise Server (GHES) support
+
+This tool works with GitHub Enterprise Server, and __supports all [GitHub Enterprise Server versions](https://docs.github.com/en/enterprise-server/admin/all-releases) currently supported by GitHub__. GitHub Enterprise Server versions are supported for approximately a year from release. 
+
+At the time of writing, the earliest supported version of GitHub Enterprise Server is 3.7. When running against GitHub Enterprise Server, the tool will check that the version is supported.
+
+You may be able to run audits against an older GitHub Enterprise Server version with an older version of `gh-migration-audit`:
+
+- To run audits against GitHub Enterprise Server 3.6, use v0.4.1 or earlier
+
 ## Contributing
 
 ### Adding a new auditor

--- a/src/github-products.ts
+++ b/src/github-products.ts
@@ -12,7 +12,7 @@ type GhesMetaResponse = DotcomMetaResponse & {
   };
 };
 
-export const MINIMUM_SUPPORTED_GITHUB_ENTERPRISE_SERVER_VERSION = '3.6.0';
+export const MINIMUM_SUPPORTED_GITHUB_ENTERPRISE_SERVER_VERSION = '3.7.0';
 
 export const isSupportedGitHubEnterpriseServerVersion = (version: string) =>
   semver.gte(version, MINIMUM_SUPPORTED_GITHUB_ENTERPRISE_SERVER_VERSION);


### PR DESCRIPTION
GitHub Enterprise Server 3.6 was [deprecated][1] on 2023-09-25. In line with our stated policies for this project, it is no longer supported for migration audits.

[1]: https://docs.github.com/en/enterprise-server/admin/all-releases