### PR TITLE
Check for updates automatically when running the extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,9 @@ gh migration-audit audit-repo \
     # OPTIONAL: Whether to emit detailed, verbose logs
     --verbose \
     # OPTIONAL: Disable anonymous telemetry that gives the maintainers of this tool basic information about real-world usage
-    --disable-telemetry
+    --disable-telemetry \
+    # OPTIONAL: Skip automatic check for updates to this tool
+    --skip-update-check
 ```
 
 The tool will audit your repo, and then write a CSV file to the `--output-path` with the results.
@@ -105,7 +107,9 @@ gh migration-audit audit-all \
     # OPTIONAL: Whether to emit detailed, verbose logs
     --verbose \
     # OPTIONAL: Disable anonymous telemetry that gives the maintainers of this tool basic information about real-world usage
-    --disable-telemetry
+    --disable-telemetry \
+    # OPTIONAL: Skip automatic check for updates to this tool
+    --skip-update-check
 ```
 
 The tool will audit all of the repos, and then write a CSV file to the `--output-path` with the results.
@@ -139,7 +143,9 @@ gh migration-audit audit-repos \
     # OPTIONAL: Whether to emit detailed, verbose logs
     --verbose \
     # OPTIONAL: Disable anonymous telemetry that gives the maintainers of this tool basic information about real-world usage
-    --disable-telemetry
+    --disable-telemetry \
+    # OPTIONAL: Skip automatic check for updates to this tool
+    --skip-update-check
 ```
 
 The tool will audit all of the repos, and then write a CSV file to the `--output-path` with the results.

--- a/src/octokit.ts
+++ b/src/octokit.ts
@@ -17,7 +17,7 @@ interface OnRateLimitOptions {
 }
 
 export const createOctokit = (
-  token: string,
+  token: string | undefined,
   baseUrl: string,
   proxyUrl: string | undefined,
   logger: Logger,


### PR DESCRIPTION
This adds a new automated update check when the extension is run.

Unless the `--skip-update-check` flag is set, we'll fetch the latest extension version using the GitHub API and check that you're up to date.

If you're running an old version, we'll let you know what the latest version is and explain how to update.