### PR TITLE
feat: add auditor detecting large release assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ The results from audits with this tool are non-exhaustive - they won't identify 
 - Packages
 - Pages custom domain configuration
 - Pinned issues
+- Release assets which are too large
 - Rulesets
 - Secret Scanning alerts
 - Self-hosted runners

--- a/src/auditors/repository-releases.ts
+++ b/src/auditors/repository-releases.ts
@@ -1,0 +1,46 @@
+import { AuditorFunction, AuditorWarning } from '../types';
+import { filesize } from 'filesize';
+
+export const TYPE = 'repository-releases';
+
+const RELEASE_ASSETS_WARNING_THRESHOLD_IN_BYTES = 5 * 1000 * 1000 * 1000; // 5 GB
+
+export const auditor: AuditorFunction = async ({
+  octokit,
+  owner,
+  repo,
+}): Promise<AuditorWarning[]> => {
+  const releasesIterator = octokit.paginate.iterator(
+    'GET /repos/{owner}/{repo}/releases',
+    {
+      owner,
+      repo,
+      per_page: 100,
+    },
+  );
+
+  let releaseAssetsTotalSizeInBytes = 0;
+
+  for await (const { data: releases } of releasesIterator) {
+    const releaseAssets = releases.flatMap((release) => release.assets);
+
+    const releaseAssetsPageTotalInBytes = releaseAssets.reduce(
+      (total, asset) => total + asset.size,
+      0,
+    );
+
+    releaseAssetsTotalSizeInBytes += releaseAssetsPageTotalInBytes;
+  }
+
+  if (releaseAssetsTotalSizeInBytes >= RELEASE_ASSETS_WARNING_THRESHOLD_IN_BYTES) {
+    return [
+      {
+        message: `Your repository includes more than ${filesize(
+          RELEASE_ASSETS_WARNING_THRESHOLD_IN_BYTES,
+        )} of release assets. This may slow down your migration, or block it by taking you over the migration tool's file size limit. If you're using GitHub Enterprise Importer, you can skip migrating releases with the \`--skip-releases\` command line option.`,
+      },
+    ];
+  } else {
+    return [];
+  }
+};

--- a/src/repository-auditor.ts
+++ b/src/repository-auditor.ts
@@ -32,6 +32,7 @@ import * as repositoryEnvironments from './auditors/repository-environments';
 import * as repositoryForks from './auditors/repository-forks';
 import * as repositoryPackages from './auditors/repository-packages';
 import * as repositoryPagesCustomDomain from './auditors/repository-pages-customdomain';
+import * as repositoryReleases from './auditors/repository-releases';
 import * as repositoryRulesets from './auditors/repository-rulesets';
 import * as repositoryTagProtectionRules from './auditors/repository-tag-protection-rules';
 import * as repositoryWebhooks from './auditors/repository-webhooks';
@@ -61,6 +62,7 @@ export const DEFAULT_AUDITORS: Auditor[] = [
   repositoryForks,
   repositoryPackages,
   repositoryPagesCustomDomain,
+  repositoryReleases,
   repositoryRulesets,
   repositoryTagProtectionRules,
   repositoryWebhooks,

--- a/test/auditors/repository-releases.test.ts
+++ b/test/auditors/repository-releases.test.ts
@@ -1,0 +1,60 @@
+import fetchMock from 'fetch-mock';
+
+import { buildAuditorArguments } from '../helpers/auditors';
+import { auditor } from '../../src/auditors/repository-releases';
+
+describe('repositoryReleases', () => {
+  it('returns no warnings if there are no releases', async () => {
+    const fetch = fetchMock
+      .sandbox()
+      .getOnce('https://api.github.com/repos/test/test/releases?per_page=100', []);
+
+    const auditorArguments = buildAuditorArguments({ fetchMock: fetch });
+    const warnings = await auditor(auditorArguments);
+
+    expect(warnings).toEqual([]);
+  });
+
+  it('returns no warnings if the releases have less than 5GB of assets', async () => {
+    const fetch = fetchMock
+      .sandbox()
+      .getOnce('https://api.github.com/repos/test/test/releases?per_page=100', [
+        {
+          assets: [
+            {
+              size: 1000000000,
+            },
+          ],
+        },
+      ]);
+
+    const auditorArguments = buildAuditorArguments({ fetchMock: fetch });
+    const warnings = await auditor(auditorArguments);
+
+    expect(warnings).toEqual([]);
+  });
+
+  it('returns a warning if the releases have more than 5GB of assets', async () => {
+    const fetch = fetchMock
+      .sandbox()
+      .getOnce('https://api.github.com/repos/test/test/releases?per_page=100', [
+        {
+          assets: [
+            {
+              size: 6 * 1000000000,
+            },
+          ],
+        },
+      ]);
+
+    const auditorArguments = buildAuditorArguments({ fetchMock: fetch });
+    const warnings = await auditor(auditorArguments);
+
+    expect(warnings).toEqual([
+      {
+        message:
+          "Your repository includes more than 5 GB of release assets. This may slow down your migration, or block it by taking you over the migration tool's file size limit. If you're using GitHub Enterprise Importer, you can skip migrating releases with the `--skip-releases` command line option.",
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
Having a large volume of release assets can block your migration by pushing the migration archive over your migration tool's size limit, or it can slow your migration down.

This PR adds a new auditor which detects when there is a large volume of release assets - using 5GB as a warning threshold. If you have a lot of assets, it warns you, and advises you what you can do about it.