### PR TITLE
Bump undici from v6.11.1 to v6.19.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "octokit": "^3.1.2",
         "posthog-node": "^4.0.0",
         "semver": "^7.6.0",
-        "undici": "^6.11.1",
+        "undici": "^6.19.2",
         "winston": "^3.13.0"
       },
       "devDependencies": {
@@ -7745,11 +7745,11 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.11.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.11.1.tgz",
-      "integrity": "sha512-KyhzaLJnV1qa3BSHdj4AZ2ndqI0QWPxYzaIOio0WzcEJB9gvuysprJSLtpvc2D9mhR9jPDUk7xlJlZbH2KR5iw==",
+      "version": "6.19.2",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.19.2.tgz",
+      "integrity": "sha512-JfjKqIauur3Q6biAtHJ564e3bWa8VvT+7cSiOJHFbX4Erv6CLGDpg8z+Fmg/1OI/47RA+GI2QZaF48SSaLvyBA==",
       "engines": {
-        "node": ">=18.0"
+        "node": ">=18.17"
       }
     },
     "node_modules/universal-github-app-jwt": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "octokit": "^3.1.2",
     "posthog-node": "^4.0.0",
     "semver": "^7.6.0",
-    "undici": "^6.11.1",
+    "undici": "^6.19.2",
     "winston": "^3.13.0"
   },
   "devDependencies": {


### PR DESCRIPTION
We had to switch back to an old `undici` because of an incompatibility with our Node version (see #193), but now we have updated Node.js in #195, we can upgrade again.