### PR TITLE
Suppress automatic warning from `octokit` about the tag protections API being deprecated

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -67,13 +67,11 @@ export interface Auditor {
   auditor: AuditorFunction;
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type LoggerFn = (message: string, meta?: any) => unknown;
 export interface Logger {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  debug: (message: string, meta?: any) => unknown;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  info: (message: string, meta?: any) => unknown;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  warn: (message: string, meta?: any) => unknown;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  error: (message: string, meta?: any) => unknown;
+  debug: LoggerFn;
+  info: LoggerFn;
+  warn: LoggerFn;
+  error: LoggerFn;
 }


### PR DESCRIPTION
When a GitHub API is marked as deprecated, Octokit automatically logs a deprecation warning when it is used. This is a bit annoying and noisy. This suppresses that log by passing a custom logger function to Octokit which eats that log line.

As a follow up to this change, I will make an issue to disable the tag protections auditor on GitHub.com on the deprecation day, August 30, 2024.

Fixes #190.