### PR TITLE
Support ARM64 and migrate to SEA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ on:
 permissions:
   contents: read
 
+env:
+  NODE_VERSION: 22.x
+
 jobs:
   test_and_lint:
     name: Test and lint
@@ -19,7 +22,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4.0.3
         with:
-          node-version: 18.x
+          node-version: ${{ env.NODE_VERSION }}
           cache: "npm"
       - run: npm ci
       - run: npm run lint
@@ -51,43 +54,52 @@ jobs:
               coverage/**
 
   package:
-    name: Package binaries
-    runs-on: ubuntu-latest
+    name: Package binaries (${{ matrix.os}})
+    strategy:
+      matrix:
+        os: [ windows, macos, ubuntu ]
+    runs-on: ${{ matrix.os }}-latest
+    env:
+      PLATFORM_OS_NAME: ${{ matrix.os == 'ubuntu' && 'linux' || matrix.os }}
+      PLATFORM_NODE_EXECUTABLE_NAME: migration-audit-${{ matrix.os == 'macos' && 'darwin' || (matrix.os == 'windows' && 'win' || 'linux' )}}
+      PLATFORM_GH_EXECUTABLE_NAME: gh-migration-audit-${{ matrix.os == 'macos' && 'darwin' || (matrix.os == 'windows' && 'windows' || 'linux' )}}
+      PLATFORM_EXTENSION: ${{ matrix.os == 'macos' && '' || (matrix.os == 'windows' && '.exe' || '' )}}
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 1
+      
       - name: Setup Node.js
         uses: actions/setup-node@v4.0.3
         with:
-          node-version: 18.x
+          node-version: ${{ env.NODE_VERSION }}
+      
       - name: Install dependencies
         run: npm ci
-      - name: Generate binaries for macOS, Linux and Windows
-        run: npm run package
-      - name: Rename macOS binary to conform to GitHub CLI extension rules
-        run: mv bin/migration-audit-macos bin/gh-migration-audit-darwin-amd64
-      - name: Rename Windows binary to conform to GitHub CLI extension rules
-        run: mv bin/migration-audit-win.exe bin/gh-migration-audit-windows-amd64.exe
-      - name: Rename Linux binary to conform to GitHub CLI extension rules
-        run: mv bin/migration-audit-linux bin/gh-migration-audit-linux-amd64
-      - name: Upload macOS binary as artifact
+      
+      - name: Generate binaries
+        run: npm run packageSea ${{env.PLATFORM_OS_NAME}}
+
+      - name: Rename x64 binary to conform to GitHub CLI extension rules
+        run: mv bin/${{ env.PLATFORM_NODE_EXECUTABLE_NAME }}-x64${{env.PLATFORM_EXTENSION}} bin/${{ env.PLATFORM_GH_EXECUTABLE_NAME }}-amd64${{env.PLATFORM_EXTENSION}}
+
+      - name: Rename ARM64 binary to conform to GitHub CLI extension rules
+        run: mv bin/${{ env.PLATFORM_NODE_EXECUTABLE_NAME }}-arm64${{env.PLATFORM_EXTENSION}} bin/${{ env.PLATFORM_GH_EXECUTABLE_NAME }}-arm64${{env.PLATFORM_EXTENSION}}
+      
+      - name: Upload ARM64 binary as artifact
         uses: actions/upload-artifact@v4
         with:
-          name: package-macos
-          path: bin/gh-migration-audit-darwin-amd64
-      - name: Upload Linux binary as artifact
+          name: package-${{env.PLATFORM_OS_NAME}}-arm64
+          path: bin/${{ env.PLATFORM_GH_EXECUTABLE_NAME }}-arm64${{env.PLATFORM_EXTENSION}}
+      
+      - name: Upload x64 binary as artifact
         uses: actions/upload-artifact@v4
         with:
-          name: package-linux
-          path: bin/gh-migration-audit-linux-amd64
-      - name: Upload Windows binary as artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: package-windows
-          path: bin/gh-migration-audit-windows-amd64.exe
+          name: package-${{env.PLATFORM_OS_NAME}}-amd64
+          path: bin/${{ env.PLATFORM_GH_EXECUTABLE_NAME }}-amd64${{env.PLATFORM_EXTENSION}}
+
   create_release:
     name: Create release
     if: startsWith(github.ref, 'refs/tags/')
@@ -98,27 +110,44 @@ jobs:
       contents: write
 
     steps:
-      - name: Download Windows binary
+      - name: Download Windows x64 binary
         uses: actions/download-artifact@v4
         with:
-          name: package-windows
+          name: package-windows-amd64
           path: bin
-      - name: Download macOS binary
+      - name: Download Windows ARM64 binary
         uses: actions/download-artifact@v4
         with:
-          name: package-macos
+          name: package-windows-arm64
           path: bin
-      - name: Download Linux binary
+      - name: Download macOS x64 binary
         uses: actions/download-artifact@v4
         with:
-          name: package-linux
+          name: package-macos-amd64
+          path: bin
+      - name: Download macOS ARM64 binary
+        uses: actions/download-artifact@v4
+        with:
+          name: package-macos-arm64
+          path: bin          
+      - name: Download Linux x64 binary
+        uses: actions/download-artifact@v4
+        with:
+          name: package-linux-amd64
+          path: bin
+      - name: Download Linux arm64 binary
+        uses: actions/download-artifact@v4
+        with:
+          name: package-linux-arm64
           path: bin
       - name: Create GitHub release
         uses: softprops/action-gh-release@v2
         with:
           files: |
             bin/gh-migration-audit-darwin-amd64
+            bin/gh-migration-audit-darwin-arm64
             bin/gh-migration-audit-linux-amd64
+            bin/gh-migration-audit-linux-arm64
             bin/gh-migration-audit-windows-amd64.exe
+            bin/gh-migration-audit-windows-arm64.exe
           generate_release_notes: true
-

--- a/.github/workflows/end-to-end-tests.yml
+++ b/.github/workflows/end-to-end-tests.yml
@@ -23,7 +23,7 @@ jobs:
         uses: dawidd6/action-download-artifact@bf251b5aa9c2f7eeb574a96ee720e24f801b7c11
         with:
           run_id: ${{ github.event.workflow_run.id }}
-          name: package-macos
+          name: package-macos-amd64
           path: bin
       - name: Create `output` directory
         run: mkdir output
@@ -79,7 +79,7 @@ jobs:
         uses: dawidd6/action-download-artifact@bf251b5aa9c2f7eeb574a96ee720e24f801b7c11
         with:
            run_id: ${{ github.event.workflow_run.id }}
-           name: package-linux
+           name: package-linux-amd64
            path: bin
       - name: Create `output` directory
         run: mkdir output
@@ -135,7 +135,7 @@ jobs:
         uses: dawidd6/action-download-artifact@bf251b5aa9c2f7eeb574a96ee720e24f801b7c11
         with:
           run_id: ${{ github.event.workflow_run.id }}
-          name: package-windows
+          name: package-windows-amd64
           path: bin
       - name: Create `output` directory
         run: mkdir output
@@ -189,7 +189,7 @@ jobs:
         uses: dawidd6/action-download-artifact@bf251b5aa9c2f7eeb574a96ee720e24f801b7c11
         with:
            run_id: ${{ github.event.workflow_run.id }}
-           name: package-linux
+           name: package-linux-amd64
            path: bin
       - name: Create `output` directory
         run: mkdir output

--- a/build.js
+++ b/build.js
@@ -1,6 +1,6 @@
 import * as esbuild from 'esbuild'
 
-import packageJson from './package.json' assert { type: 'json' }
+import packageJson from './package.json' with { type: 'json' }
 
 const result = await esbuild.build({
   entryPoints: ['src/index.ts'],

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,22 +24,29 @@
         "winston": "^3.13.0"
       },
       "devDependencies": {
+        "@smessie/readable-web-to-node-stream": "^3.0.3",
         "@types/jest": "^29.5.12",
         "@types/semver": "^7.5.8",
         "@typescript-eslint/eslint-plugin": "^7.14.1",
         "@typescript-eslint/parser": "^7.16.1",
         "@yao-pkg/pkg": "^5.12.0",
+        "axios": "^1.7.7",
         "esbuild": "^0.20.2",
         "eslint": "^8.57.0",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-prettier": "^5.1.3",
-        "fetch-mock": "^10.0.7",
+        "fetch-mock": "^10.1.1",
         "jest": "^29.7.0",
         "jest-junit": "^16.0.0",
         "prettier": "^3.3.2",
         "ts-jest": "^29.1.2",
         "ts-node": "^10.9.2",
-        "typescript": "^5.5.2"
+        "typescript": "^5.5.2",
+        "unzipper": "^0.12.3",
+        "xz-decompress": "^0.2.2"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -2389,6 +2396,66 @@
         "@sinonjs/commons": "^3.0.0"
       }
     },
+    "node_modules/@smessie/readable-web-to-node-stream": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smessie/readable-web-to-node-stream/-/readable-web-to-node-stream-3.0.3.tgz",
+      "integrity": "sha512-8FFE7psRtRWQT31/duqbmgnSf2++QLR2YH9kj5iwsHhnoqSvHdOY3SAN5e7dhc+60p2cNk7rv3HYOiXOapTEXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "process": "^0.11.10",
+        "readable-stream": "^4.5.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/@smessie/readable-web-to-node-stream/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/@smessie/readable-web-to-node-stream/node_modules/readable-stream": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.5.2.tgz",
+      "integrity": "sha512-yjavECdqeZ3GLXNgRXgeQEdz9fvDDkNKyHnbHRFtOr7/LcfgBcmct7t/ET+HaCTqfh06OzoAxrkN/IfjJBVe+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
@@ -3008,6 +3075,19 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.10.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
@@ -3183,11 +3263,12 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.2.tgz",
-      "integrity": "sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==",
+      "version": "1.7.7",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.7.tgz",
+      "integrity": "sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==",
+      "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.0",
+        "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
       }
@@ -3365,6 +3446,13 @@
         "inherits": "^2.0.4",
         "readable-stream": "^3.4.0"
       }
+    },
+    "node_modules/bluebird": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/bottleneck": {
       "version": "2.19.5",
@@ -3854,6 +3942,16 @@
       "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
       "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ=="
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz",
@@ -3912,6 +4010,49 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/duplexer2": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+      "integrity": "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "readable-stream": "^2.0.2"
+      }
+    },
+    "node_modules/duplexer2/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/duplexer2/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/duplexer2/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/ecdsa-sig-formatter": {
@@ -4247,6 +4388,26 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
     "node_modules/exit": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
@@ -4357,24 +4518,20 @@
       "integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw=="
     },
     "node_modules/fetch-mock": {
-      "version": "10.0.7",
-      "resolved": "https://registry.npmjs.org/fetch-mock/-/fetch-mock-10.0.7.tgz",
-      "integrity": "sha512-TFG42kMRJ6dZpUDeVTdXNjh5O4TchHU/UNk41a050TwKzRr5RJQbtckXDjXiQFHPKgXGUG5l2TY3ZZ2gokiXaQ==",
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/fetch-mock/-/fetch-mock-10.1.1.tgz",
+      "integrity": "sha512-R6MwxuGwlUe0K6GzdLY1Wa9voX/GbUBDZjNHBsvlBhrpXurCYpQN4EW0iFCmtWddDTuS0ubR93OtFSgy9E/L2A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "debug": "^4.1.1",
-        "glob-to-regexp": "^0.4.0",
+        "dequal": "^2.0.3",
+        "globrex": "^0.1.2",
         "is-subset": "^0.1.1",
-        "lodash.isequal": "^4.5.0",
-        "path-to-regexp": "^2.2.1",
-        "querystring": "^0.2.1"
+        "regexparam": "^3.0.0"
       },
       "engines": {
-        "node": ">=4.0.0"
-      },
-      "funding": {
-        "type": "charity",
-        "url": "https://www.justgiving.com/refugee-support-europe"
+        "node": ">=8.0.0"
       },
       "peerDependenciesMeta": {
         "node-fetch": {
@@ -4650,12 +4807,6 @@
         "node": ">=10.13.0"
       }
     },
-    "node_modules/glob-to-regexp": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
-      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
-      "dev": true
-    },
     "node_modules/globals": {
       "version": "13.23.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-13.23.0.tgz",
@@ -4690,6 +4841,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/globrex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
+      "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
@@ -6099,12 +6257,6 @@
       "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
       "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg=="
     },
-    "node_modules/lodash.isequal": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
-      "dev": true
-    },
     "node_modules/lodash.isfunction": {
       "version": "3.0.9",
       "resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-3.0.9.tgz",
@@ -6235,12 +6387,13 @@
       }
     },
     "node_modules/micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "braces": "^3.0.2",
+        "braces": "^3.0.3",
         "picomatch": "^2.3.1"
       },
       "engines": {
@@ -6588,12 +6741,6 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
     },
-    "node_modules/path-to-regexp": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-2.4.0.tgz",
-      "integrity": "sha512-G6zHoVqC6GGTQkZwF4lkuEyMbVOjoBKAEybQUypI1WTkqinCOrq2x6U2+phkJ1XsEMTy4LjtwPI7HW+NVrRR2w==",
-      "dev": true
-    },
     "node_modules/path-type": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
@@ -6794,6 +6941,16 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -6862,16 +7019,6 @@
         }
       ]
     },
-    "node_modules/querystring": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.1.tgz",
-      "integrity": "sha512-wkvS7mL/JMugcup3/rMitHmd9ecIGd2lhFhK9N3UUQ450h66d1r3Y9nvXzQAW1Lq+wyx61k/1pfKS5KuKiyEbg==",
-      "deprecated": "The querystring API is considered Legacy. new code should use the URLSearchParams API instead.",
-      "dev": true,
-      "engines": {
-        "node": ">=0.4.x"
-      }
-    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -6933,6 +7080,16 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/regexparam": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/regexparam/-/regexparam-3.0.0.tgz",
+      "integrity": "sha512-RSYAtP31mvYLkAHrOlh25pCNQ5hWnT106VukGaaFfuJrZFkGRX5GhUAdPqpSDXxOhA2c4akmRuplv1mRqnBn6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/require-directory": {
@@ -7697,6 +7854,35 @@
         "node": ">= 10.0.0"
       }
     },
+    "node_modules/unzipper": {
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.12.3.tgz",
+      "integrity": "sha512-PZ8hTS+AqcGxsaQntl3IRBw65QrBI6lxzqDEL7IAo/XCEqRTKGfOX56Vea5TH9SZczRVxuzk1re04z/YjuYCJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bluebird": "~3.7.2",
+        "duplexer2": "~0.1.4",
+        "fs-extra": "^11.2.0",
+        "graceful-fs": "^4.2.2",
+        "node-int64": "^0.4.0"
+      }
+    },
+    "node_modules/unzipper/node_modules/fs-extra": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
+      "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
     "node_modules/update-browserslist-db": {
       "version": "1.0.13",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz",
@@ -7905,6 +8091,16 @@
       "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
       "integrity": "sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw==",
       "dev": true
+    },
+    "node_modules/xz-decompress": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/xz-decompress/-/xz-decompress-0.2.2.tgz",
+      "integrity": "sha512-DSOnX+ZLVTrsW+CtjZPwjrMWvuRkzCcEpwLsY2faZyVgLH/ZHpTg3h3+KyN16mGuduMgO+/pc9rSEG735oGN0g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/package.js
+++ b/package.js
@@ -1,0 +1,402 @@
+import fs from 'node:fs';
+import child_process from 'node:child_process';
+import path from 'node:path';
+import {parseArgs} from 'node:util';
+import axios from 'axios';
+import tar from 'tar-stream';
+import xzd from 'xz-decompress';
+import unzipper from 'unzipper';
+import {ReadableWebToNodeStream} from '@smessie/readable-web-to-node-stream';
+
+const PLATFORM_NAME = {
+    WINDOWS: 'win',
+    MACOS: 'darwin',
+    LINUX: 'linux'
+};
+
+const ARCH_TYPE = {
+    ARM64: 'arm64',
+    X64: 'x64'
+};
+
+const version = '22.8.0';
+const platforms = [
+    PLATFORM_NAME.MACOS,
+    PLATFORM_NAME.LINUX,
+    PLATFORM_NAME.WINDOWS
+];
+
+const archs = [
+    ARCH_TYPE.ARM64,
+    ARCH_TYPE.X64
+];
+
+// --------- Supporting Functions  ---------------
+
+async function main() {
+    const args = process.argv;
+    const options = {
+    macSign: {
+        type: 'string',
+        short: 'm'
+    },
+    winSignPfx: {
+        type: 'string',
+        short: 'w'
+    },
+    winSignPwd: {
+        type: 'string',
+        short: 'p'
+    },
+    node: {
+        type: 'string',
+        short: 'n'
+    },
+    help: {
+        type: 'boolean'
+    }
+    };
+    const { values, positionals } = parseArgs({ args, options, allowPositionals: true });
+    
+    if (values.help) {
+        console.log('Packages the NodeJS code as a self-executing application for the specified platforms');
+        console.log('Usage: node package.js [arguments] [platforms]\n');
+
+        console.log('Platform can be macos, windows, and/or linux (default: all)')
+        console.log('Options:');
+        console.log('  --help:\t\tDisplays this help text');
+        console.log('  --macSign:\t\tCommon name for the macOS signing certificate (default: MAC_DEVELOPER_CN)');
+        console.log(`  --node:\t\tSpecific node version to use for application (default: ${version} )`);
+        console.log('  --winSignPfx:\t\tPath to the PFX file containing the signing keys for Windows (default: WIN_DEVELOPER_PFX)');
+        console.log('  --winSignPwd:\t\tPassword to use for signing the Windows application (default: WIN_DEVELOPER_PWD)');
+    }
+
+    if (values.macSign) {
+        process.env.MAC_DEVELOPER_CN = values.macSign;
+    }
+
+    if (values.winSignPfx) {
+        process.env.WIN_DEVELOPER_PFX = values.winSignPfx;
+    }
+
+    if (values.winSignPwd) {
+        process.env.WIN_DEVELOPER_PWD = values.winSignPwd;
+    }
+
+    // If user specifies platforms, they must be in the list of all available platforms
+    const platformPositionals = positionals.slice(2);
+    const buildPlatforms = platformPositionals && platformPositionals.length > 0 
+                           ? platformPositionals
+                                .flatMap(t => t.split(','))
+                                .map(t => t.toLowerCase())
+                                .map(t => t === 'macos' || t === 'mac' ? PLATFORM_NAME.MACOS : t === 'windows' ? PLATFORM_NAME.WINDOWS : t)
+                                .filter(t => platforms.includes(t))
+                             : platforms;
+    await createSingleExecutableApplication(values.node ?? version, buildPlatforms, archs);
+}
+
+
+async function uncompressZip(inputStream, outputStream) {
+    //const stream = inputStream.pipe(zlib.createUnzip()).pipe(outputFile)
+    //await new Promise(resolve => stream.on('finish', resolve))
+    const zip = inputStream.pipe(unzipper.Parse({forceStream: true}));
+    for await (const entry of zip) {
+      const fileName = entry.path;
+      const type = entry.type;
+      if (type ==='File' && fileName.endsWith('/node.exe')) {
+        await new Promise((resolve, reject) =>
+        {
+            debug(`Extracting ${fileName}`);
+            entry.pipe(outputStream)
+            .on('finish', () => {
+                debug(`Extraction complete`);
+                resolve()
+            })
+            .on('error', (err) => { 
+                debug(`Extraction failed: ${err}`);
+                reject(err);
+            });
+        });
+      } else {
+        entry.autodrain();
+      }
+    }
+}
+
+async function uncompressXz(inputStream, outputStream) {
+    // Extract the node binary
+    const extract = tar.extract();
+    const chunks = [];
+
+    extract.on('entry', function (header, stream, next) {
+        if (header.name.endsWith('/bin/node')) {
+            debug(`Extracting ${header.name}`);
+            stream.on('data', function (chunk) {
+                chunks.push(chunk);
+            });
+        }
+
+        stream.on('end', function () {
+            next();
+        });
+
+        stream.resume();
+    });
+
+    extract.on('finish', function () {
+        if (chunks.length) {
+            var data = Buffer.concat(chunks);
+            outputStream.write(data);
+            debug(`Extraction complete`);
+        }
+    })
+
+    // Web stream to decompress XZ files
+    const xzDecompressStream = new xzd.XzReadableStream(inputStream);
+
+    // Convert to Node stream to pipe to the TAR extractor
+    new ReadableWebToNodeStream(xzDecompressStream)
+        .pipe(extract);
+    
+    await new Promise(resolve => extract.on('finish', resolve));
+}
+
+function exec(cmd, args){
+    const needQuotes = process.platform === 'win32' && cmd.indexOf(' ') > -1;
+    const processResult = child_process.spawnSync(
+        needQuotes ? `\"${cmd}\"` : cmd,
+        args.map(t => process.platform === 'win32' && t.indexOf(' ') > -1 ? `\"${t}\"` : t),
+        {
+            encoding: 'utf8',
+            shell: true,
+        }
+    );
+    console.log(processResult.stdout);
+    if (processResult.stderr){
+        console.error(processResult.stderr);
+    }
+}
+
+async function writeSignature(platform, arch, outputPath) {
+    if (platform === PLATFORM_NAME.MACOS && process.platform == 'darwin') {
+        if (process.env.MAC_DEVELOPER_CN) {
+            console.log("Signing binary");
+            exec('codesign', ['--sign', process.env.MAC_DEVELOPER_CN, outputPath]);
+        }
+    }
+    else if (platform  === PLATFORM_NAME.WINDOWS && process.platform === 'win32') {
+        // Not required
+        if (process.env.WIN_DEVELOPER_PFX && process.env.WIN_DEVELOPER_PWD) {
+            console.log("Signing binary");
+            exec(await findSignTool(), ['sign',
+                '/fd', 'SHA256',
+                '/f', process.env.WIN_DEVELOPER_PFX, '/p', process.env.WIN_DEVELOPER_PWD,
+                '/t', 'http://timestamp.digicert.com',
+                nodeBinaryPath]);
+        }
+    }
+}
+
+async function prepareSignature(platform, arch, nodeBinaryPath) {
+    if (platform === PLATFORM_NAME.MACOS) {
+        if (process.platform == 'darwin'){
+            console.log("Removing signature");
+            exec('codesign', ['--remove-signature', nodeBinaryPath]);
+        }
+        return ['--macho-segment-name', 'NODE_SEA'];
+    }
+    else if (platform  === PLATFORM_NAME.WINDOWS && process.platform == 'win32') {
+        console.log("Removing signature");
+        exec(await findSignTool(), ['remove', '/s', nodeBinaryPath]);
+    }
+    return [];
+}
+
+async function pathExists(filePath){
+    return await fs.promises.access(filePath).then(()=>true,()=>false);
+}
+
+async function prepareOutputDirectory() {
+    const binFolder = path.resolve('./bin');
+    if (await pathExists(binFolder)) {
+        await fs.promises.rm(binFolder, { recursive: true });
+    }
+    await fs.promises.mkdir(binFolder, { recursive: true });
+    return binFolder;
+}
+
+async function packageAsSingleExecutableApplication(binaryOutputFolder, nodeBinaryPath, platform, arch) {
+    debug('Writing executable');
+    let params = ['postject', nodeBinaryPath, 'NODE_SEA_BLOB', path.resolve(path.join(binaryOutputFolder, 'migration-audit.blob')), '--sentinel-fuse', 'NODE_SEA_FUSE_fce680ab2cc467b6e072b8b5df1996b2'];
+
+    params.concat(await prepareSignature(platform, arch, nodeBinaryPath));
+
+    // Linux will have a few warnings: https://github.com/nodejs/postject/issues/83
+    exec('npx', params);
+
+    await writeSignature(platform, arch, nodeBinaryPath);
+}
+
+async function getDownloadStream(platform, arch, nodeVersion) {
+    const compressedExtension = platform === PLATFORM_NAME.WINDOWS ? 'zip' : 'tar.xz';
+    const url = `https://nodejs.org/dist/v${nodeVersion}/node-v${nodeVersion}-${platform}-${arch}.${compressedExtension}`;
+    console.log(`Retrieving ${url}`);
+
+    const axiosOptions = {
+        method: 'GET',
+        url: url,
+        responseType: 'stream',
+    };
+
+    // To use the XZ stream handling, we need the Fetch adapter, 
+    if (platform != PLATFORM_NAME.WINDOWS) {
+        axiosOptions.adapter = 'fetch';
+    }
+
+    const response = await axios(axiosOptions);
+    return response.data;
+}
+
+async function extractNodeBinaryFromStream(platform, inputStream, outputPath) {
+    const binaryFileStream = fs.createWriteStream(outputPath);
+    debug('Processing compressed stream');
+
+    if (platform === PLATFORM_NAME.WINDOWS) {
+        await uncompressZip(inputStream, binaryFileStream);
+    }
+    else {
+        await uncompressXz(inputStream, binaryFileStream);
+    }
+
+    binaryFileStream.close();
+}
+
+function getOutputPath(platform, arch, outputFolder) {
+    const binaryExtension = platform === PLATFORM_NAME.WINDOWS ? '.exe' : '';
+    const outputPath = path.resolve(path.join(outputFolder, `migration-audit-${platform}-${arch}${binaryExtension}`));
+    return outputPath;
+}
+
+async function downloadNodePlatformBinary(platform, arch, nodeVersion, outputFolder) {
+    const outputPath = getOutputPath(platform, arch, outputFolder);
+    const responseStream = await getDownloadStream(platform, arch, nodeVersion);
+
+    // pipe the result stream into a file on disc
+    await extractNodeBinaryFromStream(platform, responseStream, outputPath);
+    return outputPath;
+}
+
+function isActionsRunner() {
+    return !!process.env.GITHUB_WORKFLOW;
+}
+
+function startGroup(group) {
+    if (isActionsRunner()){
+        console.log(`::group::${group}`);
+    }
+}
+
+function endGroup(group) {
+    if (isActionsRunner()){
+        console.log('::endgroup::');
+    }
+}
+
+function debug(message) {
+    if (isActionsRunner()){
+        console.log(`::debug::${message}`);
+    }
+    else {
+        console.debug(message);
+    }
+}
+
+function warn(message) {
+    if (isActionsRunner()){
+        console.log(`::warn::${message}`);
+        console.warn(message);
+    }
+    else {
+        console.warn(message);
+    }
+}
+
+async function discoverSignTool(programFilesPath){
+    const windowsKitsFolder = `${programFilesPath}/Windows Kits/`;
+    debug(`Searching ${windowsKitsFolder}`);
+    const kits = await fs.promises.readdir(windowsKitsFolder);
+    for (const kit of kits){
+        const kitFolderRoot = `${windowsKitsFolder}${kit}/bin/`;
+        debug(`Examining ${kitFolderRoot}`);
+        const kitVersionFolders = await fs.promises.readdir(kitFolderRoot);
+        for (const kitFolder of kitVersionFolders) {
+            const toolPath = `${kitFolderRoot}${kitFolder}/x64/signtool.exe`;
+            debug(`Seeking ${toolPath}`);
+            try {
+                const stat = await fs.promises.stat(toolPath);
+                if (stat.isFile()){
+                    const finalPath = path.resolve(toolPath);
+                    console.log(`Discovered tool at ${finalPath}`);
+                    return finalPath;
+                }
+            }
+            catch {
+                debug(`Skipping ${toolPath}`);
+            }
+        }
+    }
+
+    return undefined;
+}
+
+const discoverSignToolAndCache = (() => {
+    let cache = new Map();
+    return async (programFilesPath) => {
+        if (cache.has(programFilesPath)) {
+            return cache.get(programFilesPath);
+        }
+        startGroup("Find signtool");
+        const result = await discoverSignTool(programFilesPath);
+        if (!result){
+            result = 'signtool.exe';
+            if (process.platform === 'win32') {
+                warn('Signtool not found. Relying on path.');
+            }
+        }
+        cache.set(programFilesPath, result);
+        endGroup();
+        return result;
+    };
+})();
+
+async function findSignTool(programFilesPath = 'C:/Program Files (x86)') {
+    let signtool = undefined;
+    if (process.platform === 'win32') {
+        signtool = await discoverSignToolAndCache(programFilesPath);
+    }
+
+    if (!signtool){
+        signtool = 'signtool.exe';
+        if (process.platform === 'win32') {
+            warn('Signtool not found. Relying on path.');
+        }
+    }
+
+    return signtool;
+}
+
+async function createSingleExecutableApplication(nodeVersion, platforms, archs) {
+    const binaryOutputFolder = await prepareOutputDirectory();
+
+    exec('node', ['build.js']);
+    exec('node', ['--experimental-sea-config', 'sea-config.json']);
+
+    for (const platform of platforms) {
+        for (const arch of archs) {
+            const nodeBinaryPath = await downloadNodePlatformBinary(platform, arch, nodeVersion, binaryOutputFolder);
+            await packageAsSingleExecutableApplication(binaryOutputFolder, nodeBinaryPath, platform, arch);
+        }
+    }
+}
+
+await main();

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "description": "Audits GitHub repositories to highlight data that cannot be automatically migrated using GitHub's migration tools",
   "homepage": "https://github.com/timrogers/gh-migration-audit",
   "scripts": {
-    "package": "node build.js && npx pkg dist/migration-audit.cjs --out-path bin --targets node20-linux-x64,node20-macos-x64,node20-win-x64",
+    "package": "node build.js && npx pkg dist/migration-audit.cjs --out-path bin --targets node20-linux-x64,node20-linux-arm64,node20-macos-x64,node20-win-x64",
+    "packageSea": "node package.js",
     "lint": "eslint . --ext .ts",
     "lint-and-fix": "eslint . --ext .ts --fix",
     "dev": "node --experimental-specifier-resolution=node --loader ts-node/esm src/index.ts",
@@ -30,25 +31,32 @@
     "winston": "^3.13.0"
   },
   "devDependencies": {
+    "@smessie/readable-web-to-node-stream": "^3.0.3",
     "@types/jest": "^29.5.12",
     "@types/semver": "^7.5.8",
     "@typescript-eslint/eslint-plugin": "^7.14.1",
     "@typescript-eslint/parser": "^7.16.1",
     "@yao-pkg/pkg": "^5.12.0",
+    "axios": "^1.7.7",
     "esbuild": "^0.20.2",
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^5.1.3",
-    "fetch-mock": "^10.0.7",
+    "fetch-mock": "^10.1.1",
     "jest": "^29.7.0",
     "jest-junit": "^16.0.0",
     "prettier": "^3.3.2",
     "ts-jest": "^29.1.2",
     "ts-node": "^10.9.2",
-    "typescript": "^5.5.2"
+    "typescript": "^5.5.2",
+    "unzipper": "^0.12.3",
+    "xz-decompress": "^0.2.2"
   },
   "repository": {
     "type": "git",
     "url": "https://github.com/timrogers/gh-migration-audit.git"
+  },
+  "engines": {
+    "node": ">=20"
   }
 }

--- a/sea-config.json
+++ b/sea-config.json
@@ -1,0 +1,7 @@
+{
+    "main": "dist/migration-audit.cjs",
+    "output": "bin/migration-audit.blob",
+    "disableExperimentalSEAWarning": true,
+    "useSnapshot": false,
+    "useCodeCache": false
+  } 


### PR DESCRIPTION
This PR modifies the code to support generating binaries for all platforms supported by node. It specifically builds Linux, macOS, and Windows binaries for ARM64 and x64. This could replace the `pkg` tool (which is now deprecated and the repo archived) with the native [SEA](https://nodejs.org/api/single-executable-applications.html) functionality. I have left the original `pkg` functionality and introduced a `packageSea` task in `package.json` that calls a new file, `package.js`, which provides a CLI that wraps the entire process.
The artifacts created by the CI process are also suffixed with the architecture. Since the runners are all Intel/AMD x64 based, the various other workflows were updated to only use those versions of the binaries.
There is additional code to support Windows and macOS code signing. These tasks are skipped unless appropriate environment variables or command line options are provided. The macOS ARM64 binaries will not execute without a signature, but all of the others work without signature.