### PR TITLE
feat: drop support for GitHub Enterprise Server v3.7, v3.8, v3.9 and v3.10, and add support for auditing rulesets and custom properties on recent GHES versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ A [GitHub CLI](https://cli.github.com/) [extension](https://cli.github.com/manua
 
 You can use this tool to identify data that will be lost, or which you'll need to migrate manually, when migrating:
 
-* from GitHub Enterprise Server (GHES) v3.7 onwards to GitHub Enterprise Cloud (GHEC)
-* from GitHub Enterprise Cloud (GHEC) to GitHub Enterprise Server (GHES)
-* between tenants on GitHub.com (e.g. from a normal GitHub.com account to an [Enterprise Managed Users](https://docs.github.com/en/enterprise-cloud@latest/admin/identity-and-access-management/using-enterprise-managed-users-for-iam/about-enterprise-managed-users) organization)
+- from GitHub Enterprise Server (GHES) v3.11 onwards to GitHub Enterprise Cloud (GHEC)
+- from GitHub Enterprise Cloud (GHEC) to GitHub Enterprise Server (GHES)
+- between tenants on GitHub.com (e.g. from a normal GitHub.com account to an [Enterprise Managed Users](https://docs.github.com/en/enterprise-cloud@latest/admin/identity-and-access-management/using-enterprise-managed-users-for-iam/about-enterprise-managed-users) organization)
 
 The results from audits with this tool are non-exhaustive - they won't identify every possible kind of data loss from a migration - but the goal is to get you 95% of the way there.
 

--- a/src/auditors/repository-actions-variables.ts
+++ b/src/auditors/repository-actions-variables.ts
@@ -1,23 +1,13 @@
-import semver from 'semver';
-
 import { AuditorFunction, AuditorWarning } from '../types';
 import { pluralize } from '../utils';
 
 export const TYPE = 'repository-actions-variables';
 
 export const auditor: AuditorFunction = async ({
-  gitHubEnterpriseServerVersion,
   octokit,
   owner,
   repo,
 }): Promise<AuditorWarning[]> => {
-  if (
-    typeof gitHubEnterpriseServerVersion !== 'undefined' &&
-    semver.lt(gitHubEnterpriseServerVersion, '3.8.0')
-  ) {
-    return [];
-  }
-
   const { data } = await octokit.rest.actions.listRepoVariables({
     owner,
     repo,

--- a/src/auditors/repository-custom-properties.ts
+++ b/src/auditors/repository-custom-properties.ts
@@ -1,3 +1,4 @@
+import semver from 'semver';
 import { AuditorFunction, AuditorWarning } from '../types';
 
 export const TYPE = 'repository-custom-properties';
@@ -8,7 +9,10 @@ export const auditor: AuditorFunction = async ({
   owner,
   repo,
 }): Promise<AuditorWarning[]> => {
-  if (typeof gitHubEnterpriseServerVersion !== 'undefined') {
+  if (
+    typeof gitHubEnterpriseServerVersion !== 'undefined' &&
+    semver.lt(gitHubEnterpriseServerVersion, '3.13.0')
+  ) {
     return [];
   }
 

--- a/src/auditors/repository-dependabot-alerts.ts
+++ b/src/auditors/repository-dependabot-alerts.ts
@@ -1,23 +1,13 @@
-import semver from 'semver';
-
 import { AuditorFunction, AuditorWarning } from '../types';
 import { RequestError } from 'octokit';
 
 export const TYPE = 'repository-dependabot-alerts';
 
 export const auditor: AuditorFunction = async ({
-  gitHubEnterpriseServerVersion,
   octokit,
   owner,
   repo,
 }): Promise<AuditorWarning[]> => {
-  if (
-    typeof gitHubEnterpriseServerVersion !== 'undefined' &&
-    semver.lt(gitHubEnterpriseServerVersion, '3.8.0')
-  ) {
-    return [];
-  }
-
   try {
     const { data } = await octokit.rest.dependabot.listAlertsForRepo({
       owner,

--- a/src/auditors/repository-rulesets.ts
+++ b/src/auditors/repository-rulesets.ts
@@ -3,15 +3,10 @@ import { AuditorFunction, AuditorWarning } from '../types';
 export const TYPE = 'repository-rulesets';
 
 export const auditor: AuditorFunction = async ({
-  gitHubEnterpriseServerVersion,
   octokit,
   owner,
   repo,
 }): Promise<AuditorWarning[]> => {
-  if (typeof gitHubEnterpriseServerVersion !== 'undefined') {
-    return [];
-  }
-
   const { data: rulesets } = await octokit.rest.repos.getRepoRulesets({
     owner,
     repo,

--- a/src/github-products.ts
+++ b/src/github-products.ts
@@ -12,7 +12,7 @@ type GhesMetaResponse = DotcomMetaResponse & {
   };
 };
 
-export const MINIMUM_SUPPORTED_GITHUB_ENTERPRISE_SERVER_VERSION = '3.7.0';
+export const MINIMUM_SUPPORTED_GITHUB_ENTERPRISE_SERVER_VERSION = '3.11.0';
 
 export const isSupportedGitHubEnterpriseServerVersion = (version: string) =>
   semver.gte(version, MINIMUM_SUPPORTED_GITHUB_ENTERPRISE_SERVER_VERSION);

--- a/test/auditors/repository-actions-variables.test.ts
+++ b/test/auditors/repository-actions-variables.test.ts
@@ -43,30 +43,4 @@ describe('repositoryActionVariables', () => {
 
     expect(warnings).toEqual([]);
   });
-
-  it('no-ops if running against GitHub Enterprise Server <3.8', async () => {
-    const auditorArguments = buildAuditorArguments({
-      gitHubEnterpriseServerVersion: '3.7.3',
-    });
-    const warnings = await auditor(auditorArguments);
-
-    expect(warnings.length).toEqual(0);
-  });
-
-  it('runs if running against GitHub Enterprise Server >=3.8', async () => {
-    const fetch = fetchMock
-      .sandbox()
-      .getOnce('https://api.github.com/repos/test/test/actions/variables?per_page=1', {
-        total_count: 0,
-        variables: [],
-      });
-
-    const auditorArguments = buildAuditorArguments({
-      fetchMock: fetch,
-      gitHubEnterpriseServerVersion: '3.8.0',
-    });
-    const warnings = await auditor(auditorArguments);
-
-    expect(warnings.length).toEqual(0);
-  });
 });

--- a/test/auditors/repository-custom-properties.test.ts
+++ b/test/auditors/repository-custom-properties.test.ts
@@ -36,9 +36,23 @@ describe('repository-custom-properties', () => {
     expect(warnings.length).toEqual(0);
   });
 
-  it('no-ops if running against GitHub Enterprise Server', async () => {
+  it('no-ops if running against GitHub Enterprise Server < 3.13', async () => {
     const auditorArguments = buildAuditorArguments({
       gitHubEnterpriseServerVersion: '3.10.0',
+    });
+    const warnings = await auditor(auditorArguments);
+
+    expect(warnings.length).toEqual(0);
+  });
+
+  it('runs if running against GitHub Enterprise Server >=3.13', async () => {
+    const fetch = fetchMock
+      .sandbox()
+      .getOnce('https://api.github.com/repos/test/test/properties/values', []);
+
+    const auditorArguments = buildAuditorArguments({
+      fetchMock: fetch,
+      gitHubEnterpriseServerVersion: '3.13.0',
     });
     const warnings = await auditor(auditorArguments);
 

--- a/test/auditors/repository-dependabot-alerts.test.ts
+++ b/test/auditors/repository-dependabot-alerts.test.ts
@@ -48,30 +48,4 @@ describe('repositoryDependabotAlerts', () => {
 
     expect(warnings).toEqual([]);
   });
-
-  it('no-ops if running against GitHub Enterprise Server <3.8', async () => {
-    const auditorArguments = buildAuditorArguments({
-      gitHubEnterpriseServerVersion: '3.7.3',
-    });
-    const warnings = await auditor(auditorArguments);
-
-    expect(warnings.length).toEqual(0);
-  });
-
-  it('runs if running against GitHub Enterprise Server >=3.8', async () => {
-    const fetch = fetchMock
-      .sandbox()
-      .getOnce('https://api.github.com/repos/test/test/dependabot/alerts?per_page=1', {
-        total_count: 0,
-        variables: [],
-      });
-
-    const auditorArguments = buildAuditorArguments({
-      fetchMock: fetch,
-      gitHubEnterpriseServerVersion: '3.8.0',
-    });
-    const warnings = await auditor(auditorArguments);
-
-    expect(warnings.length).toEqual(0);
-  });
 });

--- a/test/auditors/repository-rulesets.test.ts
+++ b/test/auditors/repository-rulesets.test.ts
@@ -41,13 +41,4 @@ describe('repository-rulesets', () => {
 
     expect(warnings.length).toEqual(0);
   });
-
-  it('no-ops if running against GitHub Enterprise Server', async () => {
-    const auditorArguments = buildAuditorArguments({
-      gitHubEnterpriseServerVersion: '3.10.0',
-    });
-    const warnings = await auditor(auditorArguments);
-
-    expect(warnings.length).toEqual(0);
-  });
 });


### PR DESCRIPTION
BREAKING CHANGE: This drops support for exports from GitHub Enterprise Server 3.7, 3.8, 3.9 and 3.10 as these versions have now been [deprecated](https://docs.github.com/en/enterprise-server/admin/all-releases) by GitHub. v3.11 is now the earliest supported version.