### PR TITLE
v2.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gh-migration-audit",
-  "version": "1.5.1",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gh-migration-audit",
-      "version": "1.5.1",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
         "@fast-csv/parse": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gh-migration-audit",
-  "version": "1.5.1",
+  "version": "2.0.0",
   "type": "module",
   "description": "Audits GitHub repositories to highlight data that cannot be automatically migrated using GitHub's migration tools",
   "homepage": "https://github.com/timrogers/gh-migration-audit",


### PR DESCRIPTION
* **BREAKING CHANGE:** This drops support for exports from GitHub Enterprise Server 3.7, 3.8, 3.9 and 3.10 as these versions have now been [deprecated](https://docs.github.com/en/enterprise-server/admin/all-releases) by GitHub. v3.11 is now the earliest supported version.
* Audit custom properties and rulesets on GitHub Enterprise Server versions where they are supported