### PR TITLE
fix: no-op tag protection rules auditor on GitHub.com, since tag protection rules are now deprecated

### DIFF
--- a/src/auditors/repository-tag-protection-rules.ts
+++ b/src/auditors/repository-tag-protection-rules.ts
@@ -3,10 +3,16 @@ import { AuditorFunction, AuditorWarning } from '../types';
 export const TYPE = 'repository-tag-protection-rules';
 
 export const auditor: AuditorFunction = async ({
+  gitHubEnterpriseServerVersion,
   octokit,
   owner,
   repo,
 }): Promise<AuditorWarning[]> => {
+  // Tag protection rules are no longer supported on GitHub.com
+  if (typeof gitHubEnterpriseServerVersion === 'undefined') {
+    return [];
+  }
+
   const { data: alerts } = await octokit.rest.repos.listTagProtection({
     owner,
     repo,

--- a/test/auditors/repository-tag-protection-rules.test.ts
+++ b/test/auditors/repository-tag-protection-rules.test.ts
@@ -1,14 +1,16 @@
 import fetchMock from 'fetch-mock';
 import { auditor } from '../../src/auditors/repository-tag-protection-rules';
 import { buildAuditorArguments } from '../helpers/auditors';
+import { MINIMUM_SUPPORTED_GITHUB_ENTERPRISE_SERVER_VERSION } from '../../src/github-products';
 
 describe('repository-tag-protection-rules', () => {
-  it('returns a warning if there are tag protection rules', async () => {
+  it('running against GitHub Enterprise Server, returns a warning if there are tag protection rules', async () => {
     const fetch = fetchMock
       .sandbox()
       .getOnce('https://api.github.com/repos/test/test/tags/protection', [1, 2]);
 
     const auditorArguments = buildAuditorArguments({
+      gitHubEnterpriseServerVersion: MINIMUM_SUPPORTED_GITHUB_ENTERPRISE_SERVER_VERSION,
       fetchMock: fetch,
     });
 
@@ -22,15 +24,25 @@ describe('repository-tag-protection-rules', () => {
     ]);
   });
 
-  it('returns no warnings if there are no tag protection rules', async () => {
+  it('running against GitHub Enterprise Server, returns no warnings if there are no tag protection rules', async () => {
     const fetch = fetchMock
       .sandbox()
       .getOnce('https://api.github.com/repos/test/test/tags/protection', []);
 
     const auditorArguments = buildAuditorArguments({
+      gitHubEnterpriseServerVersion: MINIMUM_SUPPORTED_GITHUB_ENTERPRISE_SERVER_VERSION,
       fetchMock: fetch,
     });
 
+    const warnings = await auditor(auditorArguments);
+
+    expect(warnings.length).toEqual(0);
+  });
+
+  it('no-ops if running against GitHub.com', async () => {
+    const auditorArguments = buildAuditorArguments({
+      gitHubEnterpriseServerVersion: undefined,
+    });
     const warnings = await auditor(auditorArguments);
 
     expect(warnings.length).toEqual(0);


### PR DESCRIPTION
Tag protection rules were [deprecated](https://github.blog/changelog/2024-05-29-sunset-notice-tag-protections/) on GitHub.com as of August 30, 2024. This stops running the relevant auditor when auditing GitHub.com.

Fixes #199.